### PR TITLE
added lr-mess-oric; lr-mess-ti99; lr-mess-vectrex

### DIFF
--- a/scriptmodules/libretrocores/lr-mess-oric.sh
+++ b/scriptmodules/libretrocores/lr-mess-oric.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-mess-oric"
+rp_module_name="Oric Atmos"
+rp_module_ext=".tap .zip"
+rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
+rp_module_help="ROM Extensions: $rp_module_ext\n\n
+Put games in:\n
+$romdir/oric\n\n
+Put BIOS files in $biosdir:\n
+oric1.zip\n\n
+It appears that MESS/MAME do not have floppy support for the Oric Atmos, as flop-1 is an invalid command. Documentation is sparse here. The source code suggests disk support, but there is no [apparent] supporting command-line argument."
+
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
+rp_module_section="exp"
+rp_module_flags=""
+
+function depends_lr-mess-oric() {
+	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
+	if [[ ! -f "$_mess" ]]; then
+		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
+		exit 1
+	fi
+}
+
+function sources_lr-mess-oric() {
+	true
+}
+
+function build_lr-mess-oric() {
+	true
+}
+
+function install_lr-mess-oric() {
+	true
+}
+
+function configure_lr-mess-oric() {
+	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
+	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
+	local _system="oric"
+	local _config="$configdir/$_system/retroarch.cfg"
+	local _add_config="$_config.add"
+	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
+	local _script="$configdir/$_system/run_mess.sh"
+
+	# create retroarch configuration
+	ensureSystemretroconfig "$_system"
+
+	# ensure it works without softlists, using a custom per-fake-core config
+    iniConfig " = " "\"" "$_custom_coreconfig"
+    iniSet "mame_softlists_enable" "disabled"
+	iniSet "mame_softlists_auto_media" "disabled"
+	iniSet "mame_boot_from_cli" "disabled"
+
+	# this will get loaded too via --append_config
+	iniConfig " = " "\"" "$_add_config"
+	iniSet "core_options_path" "$_custom_coreconfig"
+	#iniSet "save_on_exit" "false"
+
+	# setup rom folder
+	mkRomDir "$_system"
+
+	# copy the juicy script which will do the all the hard work to the fake-core config folder
+	cp "$scriptdir/scriptmodules/run_mess.sh" "$_script"
+	chmod 755 "$_script"
+
+	# add the emulators.cfg as normal, pointing to the above script
+  addEmulator 1 "$md_id-tap" "$_system" "$_script $_retroarch_bin $_mess $_config orica $biosdir -cass %ROM%"
+  
+	# add system to es_systems.cfg as normal
+	addSystem "$_system" "$md_name" "$md_ext"
+}

--- a/scriptmodules/libretrocores/lr-mess-ti99.sh
+++ b/scriptmodules/libretrocores/lr-mess-ti99.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-mess-ti99"
+rp_module_name="TI-99/4A Home Computer"
+rp_module_ext=".rpk"
+rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
+rp_module_help="ROM Extensions: .rpk .RPK\n\n
+Put .rtp games in:\n
+  $romdir/ti99/\n\n
+Put BIOS file in $biosdir:\n
+  ti99_4a.zip (US/EU)\n
+  ti99_evpc.zip (EVPC)\n
+  ti99_speech.zip (Speech Module)\n\n
+For the TI-99/4A, MESS requires .rpk files, which are renamed ZIP files. They contain cartridge memory dumps and a layout.xml file, which informs the MESS which file belongs to which part of memory."
+
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
+rp_module_section="exp"
+rp_module_flags=""
+
+function depends_lr-mess-ti99() {
+	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
+	if [[ ! -f "$_mess" ]]; then
+		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
+		exit 1
+	fi
+}
+
+function sources_lr-mess-ti99() {
+	true
+}
+
+function build_lr-mess-ti99() {
+	true
+}
+
+function install_lr-mess-ti99() {
+	true
+}
+
+function configure_lr-mess-ti99() {
+	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
+	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
+	local _system="ti99"
+	local region
+	local regions=(_4a _4ae _4ev)
+	local _config="$configdir/$_system/retroarch.cfg"
+	local _add_config="$_config.add"
+	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
+	local _script="$configdir/$_system/run_mess.sh"
+
+	# create retroarch configuration
+	ensureSystemretroconfig "$_system"
+
+	# ensure it works without softlists, using a custom per-fake-core config
+	iniConfig " = " "\"" "$_custom_coreconfig"
+	iniSet "mame_softlists_enable" "disabled"
+	iniSet "mame_softlists_auto_media" "disabled"
+	iniSet "mame_boot_from_cli" "disabled"
+
+	# this will get loaded too via --append_config
+	iniConfig " = " "\"" "$_add_config"
+	iniSet "core_options_path" "$_custom_coreconfig"
+	#iniSet "save_on_exit" "false"
+
+	# setup rom folder
+	mkRomDir "$_system"
+
+	# copy the juicy script which will do the all the hard work to the fake-core config folder
+	cp "$scriptdir/scriptmodules/run_mess.sh" "$_script"
+	chmod 755 "$_script"
+
+	# add the emulators.cfg as normal, pointing to the above script
+	for region in "${regions[@]}"; do
+		addEmulator 1 "$md_id${region}" "$_system" "$_script $_retroarch_bin $_mess $_config ti99$region $biosdir -nat -joy -cart1 %ROM% -ioport peb -ioport:peb:slot3 speech"
+	done
+
+	# add system to es_systems.cfg as normal
+	addSystem "$_system" "$md_name" "$md_ext"
+}

--- a/scriptmodules/libretrocores/lr-mess-vectrex.sh
+++ b/scriptmodules/libretrocores/lr-mess-vectrex.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-mess-vectrex"
+rp_module_name="GCE Vectrex"
+rp_module_ext=".zip .bin"
+rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
+rp_module_help="ROM Extensions: $rp_module_ext\n\n
+Put games in:\n
+$romdir/vectrex\n\n
+Put BIOS files in $biosdir:\n
+vectrex.zip"
+
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
+rp_module_section="exp"
+rp_module_flags=""
+
+function depends_lr-mess-vectrex() {
+	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
+	if [[ ! -f "$_mess" ]]; then
+		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
+		exit 1
+	fi
+}
+
+function sources_lr-mess-vectrex() {
+	true
+}
+
+function build_lr-mess-vectrex() {
+	true
+}
+
+function install_lr-mess-vectrex() {
+	true
+}
+
+function configure_lr-mess-vectrex() {
+	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
+	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
+	local _system="vectrex"
+	local _config="$configdir/$_system/retroarch.cfg"
+	local _add_config="$_config.add"
+	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
+	local _script="$configdir/$_system/run_mess.sh"
+
+	# create retroarch configuration
+	ensureSystemretroconfig "$_system"
+
+	# ensure it works without softlists, using a custom per-fake-core config
+  iniConfig " = " "\"" "$_custom_coreconfig"
+  iniSet "mame_softlists_enable" "disabled"
+	iniSet "mame_softlists_auto_media" "disabled"
+	iniSet "mame_boot_from_cli" "disabled"
+
+	# this will get loaded too via --append_config
+	iniConfig " = " "\"" "$_add_config"
+	iniSet "core_options_path" "$_custom_coreconfig"
+	#iniSet "save_on_exit" "false"
+
+	# setup rom folder
+	mkRomDir "$_system"
+
+	# copy the juicy script which will do the all the hard work to the fake-core config folder
+	cp "$scriptdir/scriptmodules/run_mess.sh" "$_script"
+	chmod 755 "$_script"
+
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config $_system $biosdir -cart %ROM%"
+
+	# add system to es_systems.cfg as normal
+	addSystem "$_system" "$md_name" "$md_ext"
+}


### PR DESCRIPTION
Three (3) scripts to be used with the @valerino mess master script:

Oric (.tap support)
TI-99/4A (three emulators w/speech support for games such as Parsec)
Vectrex (note it's a known issue that Mine Storm cannot be launched, as it was built into the unit)