### PR TITLE
Existing install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ RetroPie-Setup
 
 [here are the additional improvements in this fork](./README-FORK.md)
 
+Installation
+------------
+
+To upgrade a vanilla RetroPie install to use these advanced scripts:
+
+- cd ~
+- mv RetroPie-Setup RetroPie-Setup-backup
+- git clone https://github.com/valerino/RetroPie-Setup.git
+- cd RetroPie-Setup
+- sudo ./retropie_setup.sh
+
 General Usage
 -------------
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -431,14 +431,31 @@ function setupDirectories() {
     mkUserDir "$romdir"
     mkUserDir "$biosdir"
 
-    # one config directory for crt, one for hdmi, defaults to hdmi
-    mkUserDir "$configdir.hdmi"
-    mkUserDir "$configdir.crt"
-    if [[ ! -L "$configdir"  ]]; then
-        # initialize
-        rm -rf "$configdir"
-	    ln -s "$configdir.hdmi" "$configdir"
+    if [[ -d "$configdir.hdmi" ]]; then
+        # hdmi directory already exists so this script has been run previously,
+        # ensure config directory exists only as a link:
+        if [[ ! -L "$configdir"  ]]; then
+            # initialize
+            rm -rf "$configdir"
+            ln -s "$configdir.hdmi" "$configdir"
+            chown $user:$user "$configdir"
+            # change the link ownership as well
+            chown -h $user:$user "$configdir"
+        fi
+    else
+        # Migrate a standard RetroPie install - one config directory for crt, one for hdmi, defaults to hdmi:
+
+        # crt:
+        mkUserDir "$configdir.crt"
+
+        # hdmi: move existing config dir to config.hdmi to preserve any existing configs:
+        mv "$configdir" "$configdir.hdmi"
+
+        # link config --> config.hdmi
+        ln -s "$configdir.hdmi" "$configdir"
         chown $user:$user "$configdir"
+        # change the link ownership as well
+        chown -h $user:$user "$configdir"
     fi
 
     mkUserDir "$configdir/all"


### PR DESCRIPTION
- Adjusted the setupDirectories logic to handle existing installations with existing contents within /opt/retropie/configs. Tested on a fresh Buster install.

- Added a short installation instruction section.