### PR TITLE
Finish the list of gaming systems from the MESS supported list

### DIFF
--- a/README-FORK.md
+++ b/README-FORK.md
@@ -55,9 +55,12 @@ __NOTE__: the following scripts allows utilizing the specified systems through M
 * lr-mess-coco: Tandy Color Computer
 * lr-mess-crvision: VTech Creativision
 * lr-mess-dragon32: Dragon 32
+* lr-mess-einstein: Tatung Einstein TC-01
 * lr-mess-electron: Acorn Electron (overrides runcommand.sh, read https://retropie.org.uk/forum/post/217553)
 * lr-mess-exl100: Exelvision EXL 100
 * lr-mess-fm7: Fujitsu FM7
+* lr-mess-fmtowns: Fujitsu FM Towns
+* lr-mess-galaxy: Elektronika inzenjering Galaxy
 * lr-mess-gamate: Bit Corporation Gamate
 * lr-mess-gamecom: Tiger Game.com
 * lr-mess-gameking: TimeTop GameKing
@@ -71,11 +74,16 @@ __NOTE__: the following scripts allows utilizing the specified systems through M
 * lr-mess-microvsn: Milton Bradley Microvision
 * lr-mess-megaduck: Mega Duck
 * lr-mess-mo5: Thomson MO5
+* lr-mess-mtx512: Memotech MTX 512
 * lr-mess-multivision: Othello Multivision
 * lr-mess-mz700: Sharp MZ700
+* lr-mess-orao: PEL Varazdin Orao
 * lr-mess-oric: Oric Atmos (contributed by @roslof)
 * lr-mess-pdp1: Digital Equipment Corporation PDP-1
+* lr-mess-pmd85: Tesla PMD-85
 * lr-mess-pockstat: Sony PocketStation
+* lr-mess-pokemini: Nintendo Pokemon Mini
+* lr-mess-primo: Microkey Primo
 * lr-mess-pv1000: Casio PV-1000
 * lr-mess-pv2000: Casio PV-2000
 * lr-mess-samcoupe: MGT Sam Coupé
@@ -88,10 +96,14 @@ __NOTE__: the following scripts allows utilizing the specified systems through M
 * lr-mess-svi318: Spectravideo 318/328
 * lr-mess-supervision: Watara Supervision
 * lr-mess-supracan: Super A'Can
+* lr-mess-svmu: Sega Visual Memory Unit
 * lr-mess-ti99: Texas Instrument TI/994A (contributed by @roslof)
 * lr-mess-to8: Thomson TO8 (no sound)
 * lr-mess-trs-80: Tandy TRS-80 Model 3
 * lr-mess-tutor: Tomy Tutor
+* lr-mess-tvc64: Videoton TVC 64
+* lr-mess-uzebox: Belogic Uzebox
 * lr-mess-vectrex: GCE Vectrex (contributed by @roslof)
 * lr-mess-vc4000: Interton VC4000 (partially working)
 * lr-mess-vg5000: Philips VG-5000
+* lr-mess-vsmile: VTech V.Smile

--- a/scriptmodules/libretrocores/lr-mess-einstein.sh
+++ b/scriptmodules/libretrocores/lr-mess-einstein.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-einstein"
+rp_module_name="Tatung Einstein TC-01"
+rp_module_ext=".zip .dsk"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/einstein"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-einstein() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-einstein() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-einstein() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-einstein() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-einstein() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="einstein"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config einstein $biosdir -flop1 %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-fmtowns.sh
+++ b/scriptmodules/libretrocores/lr-mess-fmtowns.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-fmtowns"
+rp_module_name="Fujitsu FM Towns"
+rp_module_ext=".zip .chd .cue .toc .nrg .gdi .iso .cdr"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/fmtowns"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-fmtowns() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-fmtowns() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-fmtowns() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-fmtowns() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-fmtowns() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="fmtowns"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config fmtowns $biosdir -ram 96M -cdrm %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-galaxy.sh
+++ b/scriptmodules/libretrocores/lr-mess-galaxy.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-galaxy"
+rp_module_name="Elektronika inzenjering Galaxy"
+rp_module_ext=".zip .wav .gtp"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/galaxy"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-galaxy() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-galaxy() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-galaxy() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-galaxy() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-galaxy() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="galaxy"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config galaxyp $biosdir -cass %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-mtx512.sh
+++ b/scriptmodules/libretrocores/lr-mess-mtx512.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-mtx512"
+rp_module_name="Memotech MTX 512"
+rp_module_ext=".zip .mtx .wav"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/mtx512"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-mtx512() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-mtx512() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-mtx512() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-mtx512() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-mtx512() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="mtx512"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config mtx512 $biosdir -ram 512k -cass %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-orao.sh
+++ b/scriptmodules/libretrocores/lr-mess-orao.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-orao"
+rp_module_name="PEL Varazdin Orao"
+rp_module_ext=".zip .wav .tap"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/orao"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-orao() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-orao() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-orao() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-orao() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-orao() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="orao"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config orao103 $biosdir -cass %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-pmd85.sh
+++ b/scriptmodules/libretrocores/lr-mess-pmd85.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-pmd85"
+rp_module_name="Tesla PMD-85"
+rp_module_ext=".zip .wav .pmd .tap .ptp"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/pmd85"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-pmd85() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,33 +29,36 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-pmd85() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-pmd85() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-pmd85() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-pmd85() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="pmd85"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
 	local _script="$scriptdir/scriptmodules/run_mess.sh"
 
+        # default to the games BIOS, can be overridden within the MESS settings for the rom
+        local _bios="-bios games"
+
 	# create retroarch configuration
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +77,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config pmd853 $biosdir $_bios -cass %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-pokemini.sh
+++ b/scriptmodules/libretrocores/lr-mess-pokemini.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-pokemini"
+rp_module_name="Nintendo Pokemon Mini"
+rp_module_ext=".zip .bin .min"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/pokemini"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-pokemini() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-pokemini() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-pokemini() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-pokemini() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-pokemini() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="pokemini"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config pokemini $biosdir -cart %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-primo.sh
+++ b/scriptmodules/libretrocores/lr-mess-primo.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-primo"
+rp_module_name="Microkey Primo"
+rp_module_ext=".zip .wav .ptp"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/primo"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-primo() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-primo() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-primo() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-primo() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-primo() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="primo"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+        addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config primob64 $biosdir -cass %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-svmu.sh
+++ b/scriptmodules/libretrocores/lr-mess-svmu.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-svmu"
+rp_module_name="Sega Visual Memory Unit"
+rp_module_ext=".zip .bin .vms"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/svmu"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-svmu() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-svmu() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-svmu() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-svmu() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-svmu() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="svmu"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config svmu $biosdir -quik %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-tvc64.sh
+++ b/scriptmodules/libretrocores/lr-mess-tvc64.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-tvc64"
+rp_module_name="Videoton TVC 64"
+rp_module_ext=".zip .wav .cas"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/tvc64"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-tvc64() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-tvc64() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-tvc64() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-tvc64() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-tvc64() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="tvc64"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config tvc64p $biosdir -cass %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-uzebox.sh
+++ b/scriptmodules/libretrocores/lr-mess-uzebox.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-uzebox"
+rp_module_name="Belogic Uzebox"
+rp_module_ext=".zip .bin .uze"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/uzebox"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-uzebox() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-uzebox() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-uzebox() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-uzebox() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-uzebox() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="uzebox"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config uzebox $biosdir -cart %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"

--- a/scriptmodules/libretrocores/lr-mess-vsmile.sh
+++ b/scriptmodules/libretrocores/lr-mess-vsmile.sh
@@ -9,23 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-mess-adam"
-rp_module_name="Coleco ADAM"
-rp_module_ext=".zip .rom .col .bin .wav .ddp .dsk .d77 .d88 .1dd .dfi .imd .ipf .mfi .mfm .td0 .cqm .cqi"
+rp_module_id="lr-mess-vsmile"
+rp_module_name="VTech V.Smile"
+rp_module_ext=".zip .bin"
 rp_module_desc="MESS emulator ($rp_module_name) - MESS Port for libretro"
 rp_module_help="ROM Extensions: $rp_module_ext\n\n
 Put games in:\n
-$romdir/adam\n\n
-Put BIOS files in $biosdir:\n
-adam.zip, adam_fdc.zip, adam_prn.zip\n\n
-How to load games:\n
-http://www.progettoemma.net/mess/system.php?machine=adam"
+$romdir/vsmile"
 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags=""
 
-function depends_lr-mess-adam() {
+function depends_lr-mess-vsmile() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	if [[ ! -f "$_mess" ]]; then
 		printMsgs dialog "cannot find '$_mess' !\n\nplease install 'lr-mess' package."
@@ -33,22 +29,22 @@ function depends_lr-mess-adam() {
 	fi
 }
 
-function sources_lr-mess-adam() {
+function sources_lr-mess-vsmile() {
 	true
 }
 
-function build_lr-mess-adam() {
+function build_lr-mess-vsmile() {
 	true
 }
 
-function install_lr-mess-adam()  {
+function install_lr-mess-vsmile() {
 	true
 }
 
-function configure_lr-mess-adam() {
+function configure_lr-mess-vsmile() {
 	local _mess=$(dirname "$md_inst")/lr-mess/mess_libretro.so
 	local _retroarch_bin="$rootdir/emulators/retroarch/bin/retroarch"
-	local _system="adam"
+	local _system="vsmile"
 	local _config="$configdir/$_system/retroarch.cfg"
 	local _add_config="$_config.add"
 	local _custom_coreconfig="$configdir/$_system/custom-core-options.cfg"
@@ -58,8 +54,8 @@ function configure_lr-mess-adam() {
 	ensureSystemretroconfig "$_system"
 
 	# ensure it works without softlists, using a custom per-fake-core config
-	iniConfig " = " "\"" "$_custom_coreconfig"
-	iniSet "mame_softlists_enable" "disabled"
+        iniConfig " = " "\"" "$_custom_coreconfig"
+        iniSet "mame_softlists_enable" "disabled"
 	iniSet "mame_softlists_auto_media" "disabled"
 	iniSet "mame_boot_from_cli" "disabled"
 
@@ -78,10 +74,8 @@ function configure_lr-mess-adam() {
 	# ensure run_mess.sh script is executable
 	chmod 755 "$_script"
 
-		# add the emulators.cfg as normal, pointing to the above script
-	addEmulator 1 "$md_id-cart" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cart1 %ROM%"
-        addEmulator 0 "$md_id-disk" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -flop1 %ROM%"
-        addEmulator 2 "$md_id-cass" "$_system" "$_script $_retroarch_bin $_mess $_config adam $biosdir -cass1 %ROM%"
+	# add the emulators.cfg as normal, pointing to the above script
+	addEmulator 1 "$md_id" "$_system" "$_script $_retroarch_bin $_mess $_config vsmile $biosdir -cart %ROM%"
 
 	# add system to es_systems.cfg as normal
 	addSystem "$_system" "$md_name" "$md_ext"


### PR DESCRIPTION
This is the rest of the list of systems on http://www.progettoemma.net/mess/sysset.php for which games appear to be available. This PR includes support for various for factors, including playable memory cards, full computer systems, and a tweak or to on the adam to get more software working. Whew!